### PR TITLE
Pass UnionConfig to all interpreters

### DIFF
--- a/packages/morphic/src/eq/interpreter/configs.ts
+++ b/packages/morphic/src/eq/interpreter/configs.ts
@@ -129,3 +129,11 @@ declare module "@matechs/morphic-alg/tagged-union" {
     }
   }
 }
+
+declare module "@matechs/morphic-alg/union" {
+  interface UnionConfig<Types> {
+    [EqURI]: {
+      equals: TaggedUnionA<Types, E.URI>
+    }
+  }
+}

--- a/packages/morphic/src/eq/interpreter/union.ts
+++ b/packages/morphic/src/eq/interpreter/union.ts
@@ -26,7 +26,7 @@ export const eqUnionInterpreter = memo(
             }
           },
           env,
-          { equals }
+          { equals: equals as any }
         )
       )
     }

--- a/packages/morphic/src/fc/interpreter/configs.ts
+++ b/packages/morphic/src/fc/interpreter/configs.ts
@@ -132,6 +132,14 @@ declare module "@matechs/morphic-alg/tagged-union" {
   }
 }
 
+declare module "@matechs/morphic-alg/union" {
+  interface UnionConfig<Types> {
+    [FastCheckURI]: {
+      arbs: TaggedUnionA<Types, FastCheckURI>
+    }
+  }
+}
+
 declare module "@matechs/morphic-alg/unknown" {
   interface UnknownConfig {
     [FastCheckURI]: {

--- a/packages/morphic/src/fc/interpreter/union.ts
+++ b/packages/morphic/src/fc/interpreter/union.ts
@@ -14,7 +14,9 @@ export const fcUnionInterpreter = memo(
         pipe(
           types.map((getArb) => getArb(env).arb),
           (arbs) =>
-            fcApplyConfig(config?.conf)(accessFC(env).oneof(...arbs), env, { arbs })
+            fcApplyConfig(config?.conf)(accessFC(env).oneof(...arbs), env, {
+              arbs: arbs as any
+            })
         )
       )
   })

--- a/packages/morphic/src/guard/interpreter/configs.ts
+++ b/packages/morphic/src/guard/interpreter/configs.ts
@@ -126,3 +126,11 @@ declare module "@matechs/morphic-alg/tagged-union" {
     }
   }
 }
+
+declare module "@matechs/morphic-alg/union" {
+  interface UnionConfig<Types> {
+    [GuardURI]: {
+      guards: TaggedUnionA<Types, GuardURI>
+    }
+  }
+}

--- a/packages/morphic/src/guard/interpreter/union.ts
+++ b/packages/morphic/src/guard/interpreter/union.ts
@@ -23,7 +23,7 @@ export const guardUnionInterpreter = memo(
             }
           },
           env,
-          { guards }
+          { guards: guards as any }
         )
       )
     }

--- a/packages/morphic/src/model/interpreter/configs.ts
+++ b/packages/morphic/src/model/interpreter/configs.ts
@@ -122,3 +122,11 @@ declare module "@matechs/morphic-alg/tagged-union" {
     }
   }
 }
+
+declare module "@matechs/morphic-alg/union" {
+  interface UnionConfig<Types> {
+    [ModelURI]: {
+      models: TaggedUnionLA<Types, ModelURI>
+    }
+  }
+}

--- a/packages/morphic/src/model/interpreter/union.ts
+++ b/packages/morphic/src/model/interpreter/union.ts
@@ -21,7 +21,7 @@ export const modelUnionInterpreter = memo(
                 ? withName(config?.name)(models[0])
                 : M.union(models as [Any, Any, ...Any[]], config?.name, _guards as any),
               env,
-              { models }
+              { models: models as any }
             )
           )
       )

--- a/packages/morphic/src/show/interpreter/configs.ts
+++ b/packages/morphic/src/show/interpreter/configs.ts
@@ -120,3 +120,11 @@ declare module "@matechs/morphic-alg/tagged-union" {
     }
   }
 }
+
+declare module "@matechs/morphic-alg/union" {
+  interface UnionConfig<Types> {
+    [ShowURI]: {
+      shows: TaggedUnionA<Types, S.URI>
+    }
+  }
+}

--- a/packages/morphic/src/show/interpreter/union.ts
+++ b/packages/morphic/src/show/interpreter/union.ts
@@ -23,7 +23,7 @@ export const showUnionInterpreter = memo(
             }
           },
           env,
-          { shows }
+          { shows: shows as any }
         )
       )
     }

--- a/packages/morphic/test/Morphic.test.ts
+++ b/packages/morphic/test/Morphic.test.ts
@@ -357,14 +357,19 @@ const WithF = M.make((F) =>
   })
 )
 
-const CustomUnion = make((F) =>
-  F.union(
-    F.string(),
-    F.number()
-  )([
-    (_) => (typeof _ === "string" ? O.some(_) : O.none),
-    (_) => (typeof _ === "number" ? O.some(_) : O.none)
-  ])
+const CustomUnion = M.make((F) =>
+  F.union(F.string(), F.number())(
+    [
+      (_) => (typeof _ === "string" ? O.some(_) : O.none),
+      (_) => (typeof _ === "number" ? O.some(_) : O.none)
+    ],
+    {
+      conf: {
+        [M.FastCheckURI]: (_, { module: fc }, c) => fc.oneof(...c.arbs),
+        [M.ModelURI]: (a, b, c) => a
+      }
+    }
+  )
 )
 
 describe("Morphic", () => {


### PR DESCRIPTION
Now all of the configs are passed for each of the interpreters. I was able to reuse `TaggedUnionA` and `TaggedUnionLA` types for this. Potentially those two could be renamed to be simply `UnionA` and `UnionLA`, but that could be a breaking change, so not sure if we should do this?